### PR TITLE
Make sections responsive

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -213,7 +213,15 @@ body {
   border-radius: 400px;
  }
 
-.section { padding-block: var(--section-padding); }
+.section { 
+  padding-top: 30px;
+  padding-bottom: 30px;
+
+  @media only screen and (min-width: 768px) {
+    padding-top: 120px;
+    padding-bottom: 120px;
+  }
+}
 
 .grid-list {
   display: grid;
@@ -351,8 +359,7 @@ body {
 \*-----------------------------------*/
 
 .hero {
-  padding-block-start: calc(60px + var(--section-padding));
-  padding-block-end: var(--section-padding);
+  padding-top: 120px;
   background-repeat: no-repeat;
   background-position: center;
   background-size: cover;
@@ -989,16 +996,13 @@ font-family: 'Open Sans', sans-serif;
   }
 
   .c {
-    height: 100%;
     width: 80%; /* Adjust width for smaller screens */
   }
 }
 @media (max-width: 600px) {
   .std{
-    height: 3400px;
   }
   .test {
-    height: 500px;
     flex-direction: column;
   }
 }
@@ -1047,6 +1051,7 @@ font-family: 'Open Sans', sans-serif;
 .footer {
   background-color: var(--space-cadet-2);
   color: var(--white);
+  padding-bottom: 0;
 }
 
 .footer-top {
@@ -1503,7 +1508,8 @@ font-family: 'Open Sans', sans-serif;
   .hero-banner {
     position: relative;
     padding-inline-end: 50px;
-    margin-block-start: 180px;
+    margin-block-start: 240px;
+    margin-block-end: 70px;
   }
 
   .hero .abs-img-1 {

--- a/index.html
+++ b/index.html
@@ -49,8 +49,6 @@
       body section {
         margin-bottom: 0 !important;
         /* Set margin-bottom to 0 to remove the gap between sections */
-        padding-top: 7rem !important;
-        padding-bottom: 10rem !important;
       }
     }
 


### PR DESCRIPTION
## What?
I have modified the paddings of the "section" class.

## Why?
These changes allow users to view the sections on a mobile screen without unnecessary padding.

## How?
It includes making paddings simple. I have reduced the padding for mobile screens and added a media query for screens greater than 768px. I have also removed fixed heights from the testimonial section to make it responsive.

## Screenshots

| Before| After|
|--------|--------|
|![before-1](https://github.com/aditipandey16/GlocalEdOverseas/assets/31372124/614b1fdd-65fb-40a7-be45-7e860680fc7f)| ![after-1](https://github.com/aditipandey16/GlocalEdOverseas/assets/31372124/5977957f-6d1d-40bf-ba9e-d02711584b99)|
| ![before-2](https://github.com/aditipandey16/GlocalEdOverseas/assets/31372124/c8502271-fb2d-4ddd-8435-bb0095509a6a)| ![after-2](https://github.com/aditipandey16/GlocalEdOverseas/assets/31372124/77689020-2501-4094-9947-c63c863b5dd8)| 